### PR TITLE
Allow env vars in htaccess

### DIFF
--- a/mod_php5_apache2/templates/default/web_app.conf.erb
+++ b/mod_php5_apache2/templates/default/web_app.conf.erb
@@ -40,7 +40,7 @@
 
   <% if @environment -%>
     <% @environment.each do |key, value| %>
-    SetEnv "<%= key %>" "<%= value %>"
+    SetEnvIf <%= key %> ^(.*)$ "<%= key %>=<%= value %>"
     <% end %>
   <% end %>
 


### PR DESCRIPTION
Using SetEnvIf moves the set  to an earlier part of the request process.

See https://httpd.apache.org/docs/2.4/mod/mod_env.html#setenv